### PR TITLE
Remove .getDOMNode()

### DIFF
--- a/lib/select-box.js
+++ b/lib/select-box.js
@@ -101,7 +101,7 @@ module.exports = React.createClass({displayName: 'exports',
       } else {
         this.updatePendingValue(val, cb) || this.props.onChange(val)
         this.handleClose()
-        this.refs.button.getDOMNode().focus()
+        this.refs.button.focus()
       }
     }.bind(this)
   },
@@ -141,7 +141,7 @@ module.exports = React.createClass({displayName: 'exports',
   handleOpen: function (event) {
     interceptEvent(event)
     this.setState({open: true}, function () {
-      this.refs.menu.getDOMNode().focus()
+      this.refs.menu.focus()
     })
   },
 


### PR DESCRIPTION
Fix `React DOM Component: Do not access .getDOMNode() of a DOMnode; instead, use the node directly. This DOM node was rendered by 'exports'.` bug